### PR TITLE
revert back to JSON based cogatlas initialization

### DIFF
--- a/neurovault/apps/statmaps/migrations/0026_populate_cogatlas.py
+++ b/neurovault/apps/statmaps/migrations/0026_populate_cogatlas.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from neurovault.apps.statmaps.tasks import repopulate_cognitive_atlas
+
 from django.db import models, migrations
-import os
+import json, os
 dir = os.path.abspath(os.path.dirname(__file__))
 
-
-# COGNITIVE ATLAS
-###########################################################################
 def populate_cogatlas(apps, schema_editor):
     CognitiveAtlasTask = apps.get_model("statmaps", "CognitiveAtlasTask")
     CognitiveAtlasContrast = apps.get_model("statmaps", "CognitiveAtlasContrast")
-    repopulate_cognitive_atlas(CognitiveAtlasTask,CognitiveAtlasContrast)
+    json_content = open(os.path.join(dir, "cognitiveatlas_tasks.json")).read()
+    json_content = json_content.decode("utf-8").replace('\t', '')
+    data = json.loads(json_content)
+    for item in data:
+        task = CognitiveAtlasTask(name=item["name"], cog_atlas_id=item["id"])
+        task.save()
+        for contrast in item["contrasts"]:
+            contrast = CognitiveAtlasContrast(name=contrast["conname"], cog_atlas_id=contrast["conid"], task=task)
+            contrast.save()
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
Updating the database from the online API is great, but it's also slow. This can impair development when you create and destroy containers often (and each time you need to run migrations). 

In production we will use the script to update the database. 