### PR TITLE
Use local JSON instead of the web API to perform the update.

### DIFF
--- a/neurovault/apps/statmaps/migrations/0053_auto_20150913_0657.py
+++ b/neurovault/apps/statmaps/migrations/0053_auto_20150913_0657.py
@@ -12,11 +12,13 @@ def populate_cogatlas(apps, schema_editor):
     json_content = json_content.decode("utf-8").replace('\t', '')
     data = json.loads(json_content)
     for item in data:
-        task = CognitiveAtlasTask(name=item["name"], cog_atlas_id=item["id"])
+        task = CognitiveAtlasTask.update_or_create(cog_atlas_id=item["id"],defaults={"name":item["name"]})
         task.save()
         for contrast in item["contrasts"]:
-            contrast = CognitiveAtlasContrast(name=contrast["conname"], cog_atlas_id=contrast["conid"], task=task)
-            contrast.save()
+            conobj = CognitiveAtlasContrast.objects.update_or_create(cog_atlas_id=contrast["conid"], 
+                                                                     defaults={"name":contrast["conname"],
+                                                                               "task":task})
+            conobj.save()
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
This is what happened. Back when I added the cognitive atlas models they had an integer primary key. later (after populating them from JSON using a migration) I switched from using an int as a primary key to using the cognitive atlas ID. The migration for that change did not update the foreign keys in the Cognitive Atlas Contrasts. Thus when you queried contrasts related to tasks the list was empty (because contrasts had wrong foreign keys). The easiest solution is indeed to repopulate the cognitive atlas tables. This PR does this, but using JSON rather than web API (see the discussion here: https://github.com/vsoch/NeuroVault/pull/8).